### PR TITLE
📝 Help people with CMake include silent ignore of mismatched foldername

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Create amazing transitions and filters using shaders, with user-friendly configu
 1. In-tree build
     - Build OBS Studio: https://obsproject.com/wiki/Install-Instructions
     - Check out this repository to plugins/shadertastic (⚠ not .../obs-shadertastic as git clone may do)
-    - Add `add_subdirectory(shadertastic)` to plugins/CMakeLists.txt
+    - Add `add_subdirectory(shadertastic)` to plugins/CMakeLists.txt *twice*, after each `add_subdirectory(rtmp-services)`
     - Rebuild OBS Studio
 
 1. Stand-alone build (Linux only)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Create amazing transitions and filters using shaders, with user-friendly configu
 # Build
 1. In-tree build
     - Build OBS Studio: https://obsproject.com/wiki/Install-Instructions
-    - Check out this repository to plugins/shadertastic
+    - Check out this repository to plugins/shadertastic (⚠ not .../obs-shadertastic as git clone may do)
     - Add `add_subdirectory(shadertastic)` to plugins/CMakeLists.txt
     - Rebuild OBS Studio
 


### PR DESCRIPTION
Hi,
I felt into a sneaky gotcha today : `addsubdirectory(shadertastic)` with an ill-named `plugins/obs-shadertastic` folder (as named by git clone). This name mismatch does not create errors at all under CMake / VSCode 2022 but silently ignore the plugin with no clue about why.
Regards,
That french guy :D