### PR TITLE
Fix path on warn not loading effect

### DIFF
--- a/src/shadertastic.cpp
+++ b/src/shadertastic.cpp
@@ -187,7 +187,7 @@ void load_effects(shadertastic_common *s, obs_data_t *settings, const std::strin
         std::string effect_path = zip.c_str();
 
         if (s->effects->find(effect_name) != s->effects->end()) {
-            warn("NOT LOADING EFFECT %s/%s : an effect with the name '%s' already exist", effects_dir.c_str(), zip.c_str(), effect_name.c_str());
+            warn("NOT LOADING EFFECT %s : an effect with the name '%s' already exist", zip.c_str(), effect_name.c_str());
         }
         else if (true /*shadertastic_effect_t::is_effect(effect_path)*/) {
             // TODO the check that meta.json exists is missing in archived effects... I should add it back


### PR DESCRIPTION
Hi, a log message contains a duplicate base path, at least under linux.
```
21:59:33.334: [shadertastic] NOT LOADING EFFECT /home/ludolpif/obs/shadertastic/effects//home/ludolpif/obs/shadertastic/effects/shake.filter.shadertastic : an effect with the name 'shake' already exist
21:59:33.339: [shadertastic] NOT LOADING EFFECT /home/ludolpif/obs/shadertastic/effects//home/ludolpif/obs/shadertastic/effects/shake.filter.shadertastic : an effect with the name 'shake' already exist
```
 This patch may be tested under Windows before consider merging, I didn't tried that yet.
(I can't be sure that `zip.c_str()` returns absolute path under windows as on linux, without trying it but it seems likely).